### PR TITLE
Add property name in draft-3 required error

### DIFF
--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -93,7 +93,7 @@ class ConstraintError extends Enum
             self::NOT => 'Matched a schema which it should not',
             self::ONE_OF => 'Failed to match exactly one schema',
             self::REQUIRED => 'The property %s is required',
-            self::REQUIRED_D3 => 'Is missing and it is required',
+            self::REQUIRED_D3 => 'The property %s is required',
             self::REQUIRES => 'The presence of the property %s requires that %s also be present',
             self::PATTERN => 'Does not match the regex pattern %s',
             self::PREGEX_INVALID => 'The pattern %s is invalid',

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -144,7 +144,8 @@ class UndefinedConstraint extends Constraint
             } elseif (isset($schema->required) && !is_array($schema->required)) {
                 // Draft 3 - Required attribute - e.g. "foo": {"type": "string", "required": true}
                 if ($schema->required && $value instanceof self) {
-                    $this->addError(ConstraintError::REQUIRED_D3(), $path);
+                    $propertyName = current($path->getPropertyPaths());
+                    $this->addError(ConstraintError::REQUIRED_D3(), $path, array('property' => $propertyName));
                 }
             }
         }


### PR DESCRIPTION
In case of required error with draft-3 error message is missing property names. (Similar to #91)

Creating a new PR as mentioned in #428 against 6.0.0-dev